### PR TITLE
Layout fixes for resizing the window

### DIFF
--- a/DesiredStateGenerator/DesiredStateGeneratorWindow.xaml
+++ b/DesiredStateGenerator/DesiredStateGeneratorWindow.xaml
@@ -8,7 +8,7 @@
         <CheckBox x:Name="GenerateIISSitesPoolsCtl" Content="Generate IIS Sites and Pools" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Width="229" IsChecked="True"/>
 
         <Label Content="Organize DSC:" HorizontalAlignment="Left" Margin="26,31,0,0" VerticalAlignment="Top" Width="114"/>
-        <StackPanel Margin="32,57,0,673.4" HorizontalAlignment="Left" Width="158">
+        <StackPanel Margin="32,57,0,0" HorizontalAlignment="Left" Width="158" VerticalAlignment="Top">
             <RadioButton x:Name="GenerateIisSitesPoolsSortedCtl" Content="Group By Site"  VerticalAlignment="Top" IsChecked="True" Margin="0,0,10,0"/>
             <RadioButton x:Name="GenerateIisSitesPoolsCtlComparable" Content="Pools, then Sites" VerticalAlignment="Top" Margin="0,0,4,0"/>
         </StackPanel>

--- a/DesiredStateGenerator/DesiredStateGeneratorWindow.xaml
+++ b/DesiredStateGenerator/DesiredStateGeneratorWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="DesiredState.DesiredStateGeneratorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Desired State Generator" Height="800" Width="1200">
+        Title="Desired State Generator" Height="800" Width="1200" MinHeight="300" MinWidth="500">
     <Grid>
         <Button x:Name="GenerateDscCtl" Content="Generate DSC" Height="29" Margin="44,225,0,0" VerticalAlignment="Top" Click="GenerateDscCtl_Click" HorizontalAlignment="Left" Width="138"/>
         <TextBox Name="ResultsCtl" Margin="227,10,7.6,10.4" TextWrapping="Wrap" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" FontFamily="Lucida Console"/>


### PR DESCRIPTION
- Resizing the window hides the option controls "Organize DSC".
- Specify min height and width
